### PR TITLE
Feature/129220 alterar retorno quando encerrar prova

### DIFF
--- a/routers/api.py
+++ b/routers/api.py
@@ -151,14 +151,14 @@ async def proximo_item(
                     erro_saeb = theta_ep * 55.093
 
                 return [
-                    "-1",
-                    str(len(respostas_corrigidas)),
+                    -1,
                     "NA",
                     "NA",
                     "NA",
                     "NA",
-                    str(round(theta_saeb, 12)),
-                    str(round(erro_saeb, 13))
+                    "NA",
+                    round(theta_saeb, 4),
+                    round(erro_saeb, 4)
                 ]
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/tests/test_tai.py
+++ b/tests/test_tai.py
@@ -171,7 +171,7 @@ def test_proximo_item_parada():
     
     resultado = response.json()
     # Deve retornar -1 como primeiro elemento (parada pelo critério de 32 itens)
-    assert resultado[0] == "-1"
+    assert resultado[0] == -1
 
 # Teste para verificar transformação correta do componente
 def test_normalizacao_componente(sample_request_data):


### PR DESCRIPTION
Esse PR:

- Atera retorno da API quando a prova encerrar para igualar ao retorno da API em R
- Altera teste test_proximo_item_parada para se adequar ao novo retorno

Tarefa: 129220